### PR TITLE
added handleUpdateSnippet function to fix LibrarySnippets state varia…

### DIFF
--- a/code-editor-client/src/App.tsx
+++ b/code-editor-client/src/App.tsx
@@ -1,6 +1,6 @@
 import { Editor } from "./components/Editor";
 import OutputDisplay from "./components/OutputDisplay";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import axios from "axios";
 
 import { Button, Flex, Heading, Box } from "@chakra-ui/react";
@@ -23,8 +23,9 @@ function App({ clientToken }: AppProps) {
   // );
 
   // state to hold a reference to the code editor window
-  const [editorViewRef, setEditorViewRef] =
-    useState<React.MutableRefObject<EditorView | undefined>>({ current: undefined });
+  const [editorViewRef, setEditorViewRef] = useState<
+    React.MutableRefObject<EditorView | undefined>
+  >({ current: undefined });
 
   // useEffect(() => {
   //   if (editorViewRef) {

--- a/code-editor-client/src/components/LibraryDrawer.tsx
+++ b/code-editor-client/src/components/LibraryDrawer.tsx
@@ -16,7 +16,10 @@ import LibrarySnippet from "./LibrarySnippet";
 import generateId from "../utils/generateId";
 // import { LibrarySnippetData } from "../utils/fetchLibraryData";
 import { EditorView } from "codemirror";
-import { fetchLibraryData, LibrarySnippetData } from "../utils/fetchLibraryData";
+import {
+  fetchLibraryData,
+  LibrarySnippetData,
+} from "../utils/fetchLibraryData";
 
 type DrawerPlacement = "top" | "right" | "bottom" | "left";
 
@@ -28,7 +31,7 @@ type LibraryDrawerProps = {
   // librarySnippets: LibrarySnippetData[];
   // setLibrarySnippets: Function;
   appendEditorContent: Function;
-  editorViewRef: React.MutableRefObject<EditorView | undefined>
+  editorViewRef: React.MutableRefObject<EditorView | undefined>;
 };
 
 const LibraryDrawer = ({
@@ -41,7 +44,9 @@ const LibraryDrawer = ({
   appendEditorContent,
   editorViewRef,
 }: LibraryDrawerProps) => {
-  const [librarySnippets, setLibrarySnippets] = React.useState<LibrarySnippetData[]>([]);
+  const [librarySnippets, setLibrarySnippets] = React.useState<
+    LibrarySnippetData[]
+  >([]);
   const [addSnippetMode, setAddSnippetMode] = React.useState(false);
 
   React.useEffect(() => {
@@ -75,6 +80,20 @@ const LibraryDrawer = ({
       newSnippetData,
     ]);
     setAddSnippetMode(false);
+  };
+
+  const handleUpdateSnippet = (
+    id: number,
+    newCode: string,
+    newTitle: string
+  ) => {
+    setLibrarySnippets((prevSnippets: LibrarySnippetData[]) =>
+      prevSnippets.map((snippet) =>
+        snippet.id === id
+          ? { ...snippet, code: newCode, title: newTitle }
+          : snippet
+      )
+    );
   };
 
   const handleDeleteSnippet = (id: number) => {
@@ -128,6 +147,7 @@ const LibraryDrawer = ({
                 code={snippet.code}
                 appendEditorContent={appendEditorContent}
                 handleDeleteSnippet={handleDeleteSnippet}
+                handleUpdateSnippet={handleUpdateSnippet}
               />
             ))}
           </SimpleGrid>

--- a/code-editor-client/src/components/LibrarySnippet.tsx
+++ b/code-editor-client/src/components/LibrarySnippet.tsx
@@ -18,6 +18,7 @@ type LibrarySnippetType = {
   code: string;
   appendEditorContent: Function;
   handleDeleteSnippet: Function;
+  handleUpdateSnippet: Function;
 };
 
 const LibrarySnippet = ({
@@ -26,6 +27,7 @@ const LibrarySnippet = ({
   code,
   appendEditorContent,
   handleDeleteSnippet,
+  handleUpdateSnippet,
 }: LibrarySnippetType) => {
   const [isEditing, setIsEditing] = useState(false);
   const [snippetCode, setSnippetCode] = useState(code);
@@ -44,6 +46,7 @@ const LibrarySnippet = ({
     if (editorViewRef.current) {
       const currentContent = editorViewRef.current.state.doc.toString();
       setSnippetCode(currentContent);
+      handleUpdateSnippet(id, currentContent, snippetTitle);
     }
     setIsEditing((prevState) => !prevState);
   };


### PR DESCRIPTION
After changing the structure of our front end code to render `LibrarySnippets` from JS objects right as they are needed for display, instead of creating the component `LibrarySnippets` array of components ahead of time in the fetch data method, stored snippet JS objects weren't being updated anymore after clicking 'Save Snippet' when editing an existing one. 
-  added a `handleUpdateSnippet` button to properly update the `LibrarySnippets` state array with the new, edited data when a user clicks 'Save Snippet'
- this method is created in `LibraryDrawer` and passed as a prop to the  `LibrarySnippet`  component when it's invoked. 