### PR TITLE
Adding room-based voice chat to Umbra via integrating 'urlac' ( https://github.com/elsif-maj/urlac )

### DIFF
--- a/code-editor-client/src/components/AudioChatButton.jsx
+++ b/code-editor-client/src/components/AudioChatButton.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { useState } from "react"
+import audioChatConnect from "../services/audioChat"
+import {
+  Tooltip,
+  IconButton,
+  useColorModeValue,
+} from "@chakra-ui/react";
+import { PhoneIcon } from "@chakra-ui/icons";
+
+const AudioChatButton = () => {
+  const [urlacIsOn, setUrlacIsOn] = useState(false)
+  const [pc, setPc] = useState()
+  const [ws, setWs] = useState()
+
+  const handleAudioChatToggleButton = (e) => {
+    e.preventDefault()
+
+    audioChatConnect(
+      urlacIsOn,
+      setUrlacIsOn,
+      pc, 
+      setPc,
+      ws,
+      setWs
+    )
+  }
+
+  return (
+    urlacIsOn ? (
+    <Tooltip
+      label='Click to leave audio chat'
+      fontSize='md'
+      bg={useColorModeValue("orange.200", "orange.900")}
+      color={useColorModeValue("gray.600", "white")}
+    >
+    <IconButton
+        icon={<PhoneIcon color='white' />}
+        ml={6}
+        onClick={handleAudioChatToggleButton}
+        variant='solid'
+        bg='linear-gradient(225deg, hsla(184, 100%, 54%, 1) 0%, hsla(210, 100%, 50%, 1) 100%)'
+        aria-label='Leave Audio Chat'
+        _hover={{
+          bg: "linear-gradient(225deg, hsla(210, 100%, 50%, 1) 0%, hsla(184, 100%, 54%, 1) 100%)",
+        }}
+        textAlign='end'
+      />
+    </Tooltip>
+    ) : (
+    <Tooltip
+      label='Click to join audio chat'
+      fontSize='md'
+      bg={useColorModeValue("orange.200", "orange.900")}
+      color={useColorModeValue("gray.600", "white")}
+    >
+    <IconButton
+        icon={<PhoneIcon color='white' />}
+        ml={6}
+        onClick={handleAudioChatToggleButton}
+        variant='solid'
+        bg='linear-gradient(225deg, hsla(184, 100%, 54%, 1) 0%, hsla(210, 100%, 50%, 1) 100%)'
+        aria-label='Join Audio Chat'
+        _hover={{
+          bg: "linear-gradient(225deg, hsla(210, 100%, 50%, 1) 0%, hsla(184, 100%, 54%, 1) 100%)",
+        }}
+        textAlign='end'
+      />
+    </Tooltip>
+    )
+
+    // <Tooltip
+    //   label='Click to join audio chat'
+    //   fontSize='md'
+    //   bg={useColorModeValue("orange.200", "orange.900")}
+    //   color={useColorModeValue("gray.600", "white")}
+    // >
+    // <IconButton
+    //     icon={<PhoneIcon color='white' />}
+    //     ml={6}
+    //     onClick={handleAudioChatToggleButton}
+    //     variant='solid'
+    //     bg='linear-gradient(225deg, hsla(184, 100%, 54%, 1) 0%, hsla(210, 100%, 50%, 1) 100%)'
+    //     aria-label='Join Audio Chat'
+    //     _hover={{
+    //       bg: "linear-gradient(225deg, hsla(210, 100%, 50%, 1) 0%, hsla(184, 100%, 54%, 1) 100%)",
+    //     }}
+    //     textAlign='end'
+    //   />
+    // </Tooltip>
+  )
+}
+
+
+export default AudioChatButton;

--- a/code-editor-client/src/components/AudioChatButton.jsx
+++ b/code-editor-client/src/components/AudioChatButton.jsx
@@ -12,61 +12,68 @@ const AudioChatButton = () => {
   const [urlacIsOn, setUrlacIsOn] = useState(false)
   const [pc, setPc] = useState()
   const [ws, setWs] = useState()
+  // const [roomString, _] = useState()
+
+  
 
   const handleAudioChatToggleButton = (e) => {
     e.preventDefault()
 
+    const url = new URL(window.location.href);
+    let roomName = url.searchParams.get("room");
+    
     audioChatConnect(
       urlacIsOn,
       setUrlacIsOn,
-      pc, 
+      pc,
       setPc,
       ws,
-      setWs
+      setWs,
+      roomName
     )
   }
 
   return (
     urlacIsOn ? (
-    <Tooltip
-      label='Click to leave audio chat'
-      fontSize='md'
-      bg={useColorModeValue("orange.200", "orange.900")}
-      color={useColorModeValue("gray.600", "white")}
-    >
-    <IconButton
-        icon={<PhoneIcon color='white' />}
-        ml={6}
-        onClick={handleAudioChatToggleButton}
-        variant='solid'
-        bg='linear-gradient(225deg, hsla(184, 100%, 54%, 1) 0%, hsla(210, 100%, 50%, 1) 100%)'
-        aria-label='Leave Audio Chat'
-        _hover={{
-          bg: "linear-gradient(225deg, hsla(210, 100%, 50%, 1) 0%, hsla(184, 100%, 54%, 1) 100%)",
-        }}
-        textAlign='end'
-      />
-    </Tooltip>
+      <Tooltip
+        label='Click to leave voice chat'
+        fontSize='md'
+        bg={useColorModeValue("orange.200", "orange.900")}
+        color={useColorModeValue("gray.600", "white")}
+      >
+        <IconButton
+          icon={<PhoneIcon color='white' />}
+          ml={6}
+          onClick={handleAudioChatToggleButton}
+          variant='solid'
+          bg='linear-gradient(225deg, hsla(184, 100%, 54%, 1) 0%, hsla(210, 100%, 50%, 1) 100%)'
+          aria-label='Leave Voice Chat'
+          _hover={{
+            bg: "linear-gradient(225deg, hsla(210, 100%, 50%, 1) 0%, hsla(184, 100%, 54%, 1) 100%)",
+          }}
+          textAlign='end'
+        />
+      </Tooltip>
     ) : (
-    <Tooltip
-      label='Click to join audio chat'
-      fontSize='md'
-      bg={useColorModeValue("orange.200", "orange.900")}
-      color={useColorModeValue("gray.600", "white")}
-    >
-    <IconButton
-        icon={<PhoneIcon color='white' />}
-        ml={6}
-        onClick={handleAudioChatToggleButton}
-        variant='solid'
-        bg='linear-gradient(225deg, hsla(184, 100%, 54%, 1) 0%, hsla(210, 100%, 50%, 1) 100%)'
-        aria-label='Join Audio Chat'
-        _hover={{
-          bg: "linear-gradient(225deg, hsla(210, 100%, 50%, 1) 0%, hsla(184, 100%, 54%, 1) 100%)",
-        }}
-        textAlign='end'
-      />
-    </Tooltip>
+      <Tooltip
+        label='Click to join voice chat'
+        fontSize='md'
+        bg={useColorModeValue("orange.200", "orange.900")}
+        color={useColorModeValue("gray.600", "white")}
+      >
+        <IconButton
+          icon={<PhoneIcon color='white' />}
+          ml={6}
+          onClick={handleAudioChatToggleButton}
+          variant='solid'
+          bg='linear-gradient(225deg, hsla(184, 100%, 54%, 1) 0%, hsla(210, 100%, 50%, 1) 100%)'
+          aria-label='Join Voice Chat'
+          _hover={{
+            bg: "linear-gradient(225deg, hsla(210, 100%, 50%, 1) 0%, hsla(184, 100%, 54%, 1) 100%)",
+          }}
+          textAlign='end'
+        />
+      </Tooltip>
     )
 
     // <Tooltip

--- a/code-editor-client/src/components/AudioChatButton.jsx
+++ b/code-editor-client/src/components/AudioChatButton.jsx
@@ -75,26 +75,6 @@ const AudioChatButton = () => {
         />
       </Tooltip>
     )
-
-    // <Tooltip
-    //   label='Click to join audio chat'
-    //   fontSize='md'
-    //   bg={useColorModeValue("orange.200", "orange.900")}
-    //   color={useColorModeValue("gray.600", "white")}
-    // >
-    // <IconButton
-    //     icon={<PhoneIcon color='white' />}
-    //     ml={6}
-    //     onClick={handleAudioChatToggleButton}
-    //     variant='solid'
-    //     bg='linear-gradient(225deg, hsla(184, 100%, 54%, 1) 0%, hsla(210, 100%, 50%, 1) 100%)'
-    //     aria-label='Join Audio Chat'
-    //     _hover={{
-    //       bg: "linear-gradient(225deg, hsla(210, 100%, 50%, 1) 0%, hsla(184, 100%, 54%, 1) 100%)",
-    //     }}
-    //     textAlign='end'
-    //   />
-    // </Tooltip>
   )
 }
 

--- a/code-editor-client/src/components/MainHeader.tsx
+++ b/code-editor-client/src/components/MainHeader.tsx
@@ -122,11 +122,11 @@ const MainHeader = ({
       <Flex align='baseline'>
         <ShareRoomButton />
         <Text mx={2} color={"lightblue.600"} fontSize='18px' fontWeight={700}>
-          Share and Edit Collaboratively
+          Multiplayer 
         </Text>
         <AudioChatButton />
         <Text mx={2} color={"lightblue.600"} fontSize='18px' fontWeight={700}>
-          Join or Leave Audio Chat 
+          Voice Chat 
         </Text>
       </Flex>
       <Spacer />

--- a/code-editor-client/src/components/MainHeader.tsx
+++ b/code-editor-client/src/components/MainHeader.tsx
@@ -18,6 +18,7 @@ import LoginModal from "./LoginModal";
 import SignUpModal from "./SignUpModal";
 import ConfirmCodeModal from "./ConfirmCodeModal";
 import ShareRoomButton from "./ShareRoomButton";
+import AudioChatButton from "./AudioChatButton"
 import { ToastPropsType } from "./UmbraToast";
 import { ExtendedCognitoUser } from "../types/types";
 
@@ -122,6 +123,10 @@ const MainHeader = ({
         <ShareRoomButton />
         <Text mx={2} color={"lightblue.600"} fontSize='18px' fontWeight={700}>
           Share and Edit Collaboratively
+        </Text>
+        <AudioChatButton />
+        <Text mx={2} color={"lightblue.600"} fontSize='18px' fontWeight={700}>
+          Join or Leave Audio Chat 
         </Text>
       </Flex>
       <Spacer />

--- a/code-editor-client/src/services/audioChat.js
+++ b/code-editor-client/src/services/audioChat.js
@@ -4,7 +4,8 @@ function audioChatConnect(
   pc,
   setPc,
   ws,
-  setWs
+  setWs,
+  roomName
 ) {
   if (urlacIsOn) {
     pc.close()
@@ -30,7 +31,7 @@ function audioChatConnect(
       setPc(pc)
 
       //// WS ////
-      let ws = new WebSocket("wss://erlacmaj.com/websocket/")
+      let ws = new WebSocket("wss://erlacmaj.com/websocket/" + roomName)
       setWs(ws)
 
       // Send a heartbeat every 5 seconds

--- a/code-editor-client/src/services/audioChat.js
+++ b/code-editor-client/src/services/audioChat.js
@@ -1,0 +1,105 @@
+function audioChatConnect(
+  urlacIsOn,
+  setUrlacIsOn,
+  pc,
+  setPc,
+  ws,
+  setWs
+) {
+  if (urlacIsOn) {
+    pc.close()
+    ws.close()
+    setUrlacIsOn(!urlacIsOn)
+    return
+  }
+  setUrlacIsOn(!urlacIsOn)
+
+  navigator.mediaDevices.getUserMedia({ audio: true })
+    .then(stream => {
+      //// RTC and tracks for SDP ////
+      let pc = new RTCPeerConnection()
+
+      pc.ontrack = function (event) {
+        const audio = new Audio();
+        const otherPersonStream = new MediaStream([event.track])
+        audio.srcObject = otherPersonStream;
+        audio.play();
+      }
+
+      stream.getTracks().forEach(track => pc.addTrack(track, stream))
+      setPc(pc)
+
+      //// WS ////
+      let ws = new WebSocket("wss://erlacmaj.com/websocket/")
+      setWs(ws)
+
+      // Send a heartbeat every 5 seconds
+      setInterval(() => {
+        if (ws.readyState === ws.OPEN) {
+          ws.send(JSON.stringify({ event: 'heartbeat', data: 'ping' }));
+        }
+      }, 5000);
+
+      window.addEventListener('beforeunload', function (event) {
+        if (document.visibilityState === 'hidden' && pc) {
+          console.log('THIS FIRED')
+          pc.close();
+          ws.close();
+        }
+      });
+
+      pc.onicecandidate = e => {
+        if (!e.candidate) {
+          return
+        }
+
+        ws.send(JSON.stringify({ event: 'candidate', data: JSON.stringify(e.candidate) }))
+      }
+
+      ws.onclose = function (evt) {
+        window.alert("You have left the audio chatroom")
+      }
+
+      ws.onmessage = function (evt) {
+        let msg = JSON.parse(evt.data)
+        if (!msg) {
+          return console.log('failed to parse msg')
+        }
+
+        switch (msg.event) {
+          case 'offer':
+            let offer = JSON.parse(msg.data)
+            if (!offer) {
+              return console.log('failed to parse answer')
+            }
+
+            pc.setRemoteDescription(offer)
+              .then(() => pc.createAnswer())
+              .then(answer => {
+                pc.setLocalDescription(answer)
+                ws.send(JSON.stringify({ event: 'answer', data: JSON.stringify(answer) }))
+              })
+              .catch(error => {
+                console.error('Error during setRemoteDescription/createAnswer: ', error)
+              })
+
+            return
+
+          case 'candidate':
+            let candidate = JSON.parse(msg.data)
+            if (!candidate) {
+              return console.log('failed to parse candidate')
+            }
+
+            pc.addIceCandidate(candidate)
+        }
+      }
+
+      ws.onerror = function (evt) {
+        console.log("ERROR (evt.data): " + evt.data)
+        console.log("ERROR (evt): " + evt)
+      }
+    }).catch(window.alert)
+}
+
+export default audioChatConnect;


### PR DESCRIPTION
This PR is to test out the integration of room-based, SFU-backed, WebRTC audio chat into Umbra.

The SFU code can be found in main.go here: https://github.com/elsif-maj/urlac

The majority of the code that is actually added in this PR is just client-side code for the audio chat UI button, and a way of grabbing the user's Umbra 'room' name from the query string and sending all of this off to the SFU hosted on a DO droplet currently under my personal DO account. This can easily enough be moved over to the Umbra team DO account in the future.

While I was hoping not to change anything outside of adding a button, the label 'Share and Edit Collaboratively' for our button that copies the room-name-string to a user's system clipboard has been changed for now to allow room for the new voice-chat button and button description.  While on larger screens there was no problem, on my 13-inch Macbook screen in windowed browsing mode adding a new button and a few words of description to the header was enough to make the header into requiring two lines of text, which it expanded to accommodate and which threw off all of the styling and made it look awful.  We can try to work on the styling for this, or maybe the current solution is fine, wherein I have relabeled that button 'Multiplayer' instead of its previous description -- a label that is unfortunately (given how much I hate that term for non-game collaborative apps) both perfectly terse and descriptive.